### PR TITLE
add license note in readme for xxljob-demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,8 @@ This demo is powered by the following projects and products:
 
 * edas-demo
 * schedulerx-demo
+* csb-gateway-demo
+* xxljob-demo
+
+Files under the "xxljob-demo/" directory are licensed under the GPL v3 license( see file xxljob-demo/LICENSE).
+Files outside of the above mentioned directory are licensed under the MIT license( see file LICENSE).


### PR DESCRIPTION
Demo xxljob-demo included dependency xxl-job which is using GPL v3.0 license. 
Add descriptions to the readme file for the license conflict issue.